### PR TITLE
refactor: 패키지 종속성 및 타입 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <h2 align="middle">동글의 레이아웃 컴포넌트</h2>
-<p align="middle">![우아한테크코스 5기 프로젝트 동글](https://donggle.blog)</p>
+<p align="middle">우아한테크코스 5기 프로젝트 <a href="https://donggle.blog">동글</a></p>
 <br/>
 
 # layout-component &middot; [![NPM Version](https://img.shields.io/npm/v/@donggle/layout-component)](https://www.npmjs.com/package/@donggle/layout-component) [![GitHub license](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/yogjin/layout-component/blob/main/LICENSE)

--- a/package.json
+++ b/package.json
@@ -52,9 +52,7 @@
     "storybook": "^7.4.2",
     "typescript": "^5.2.2",
     "vite": "^4.4.5",
-    "vite-plugin-dts": "^3.6.0"
-  },
-  "dependencies": {
+    "vite-plugin-dts": "^3.6.0",
     "@typescript-eslint/eslint-plugin": "^6.0.0",
     "@typescript-eslint/parser": "^6.0.0",
     "@vitejs/plugin-react": "^4.0.3",
@@ -64,6 +62,11 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "styled-components": "^6.0.8"
+  },
+  "peerDependencies": {
+    "react": ">= 18",
+    "react-dom": ">= 18",
+    "styled-components": ">= 6"
   },
   "bugs": {
     "url": "https://github.com/2023donggle/react-drawer/issues"

--- a/src/components/Drawer/Drawer.tsx
+++ b/src/components/Drawer/Drawer.tsx
@@ -1,4 +1,4 @@
-import { PropsWithChildren } from 'react';
+import { MouseEventHandler, PropsWithChildren } from 'react';
 import styled, { css } from 'styled-components';
 
 export type Anchor = 'left' | 'right' | 'top' | 'bottom';
@@ -22,7 +22,7 @@ type Props = {
    *
    * @dafault undefined
    */
-  onClose: Function;
+  onClose: MouseEventHandler<HTMLDivElement>;
 };
 
 const Drawer = ({
@@ -34,7 +34,7 @@ const Drawer = ({
 }: PropsWithChildren<Props>) => {
   return (
     <>
-      {open && <Backdrop onClick={() => onClose()} open={open} />}
+      {open && <Backdrop onClick={onClose} open={open} />}
       <StyledDrawer anchor={anchor} open={open} size={size}>
         {children}
       </StyledDrawer>

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,7 +14,7 @@ export default defineConfig({
       fileName: 'index',
     },
     rollupOptions: {
-      external: ['src/stories/**', 'react', 'react-dom'],
+      external: ['src/stories/**', 'react', 'react-dom', 'styled-components'],
       output: {
         globals: {
           react: 'React',


### PR DESCRIPTION
1. README 링크 수정

<img width="319" alt="image" src="https://github.com/2023donggle/react-drawer/assets/57815133/9c204eab-75ea-4de7-909f-b01efda16deb">

2. Drawer의 onClose타입 수정

이거는 린트 오류가 떠있길래 수정해보았는데요.

> Don't use `Function` as a type. The `Function` type accepts any function-like value.
It provides no type safety when calling the function, which can be a common source of bugs.
It also accepts things like class declarations, which will throw at runtime as they will not be called with `new`.

`backdrop 클릭 시 실행할 핸들러`라고 설명이 쓰여있는데 그에 맞게 타입을 주면 어떨까 싶어서 수정해보았습니다.

3. 패키지 종속성 수정

사실 이 PR을 날린 이유인데요..

<img width="318" alt="image" src="https://github.com/2023donggle/react-drawer/assets/57815133/7991d6e4-2cbd-4486-867e-a80a1624d9a0">

이 패키지의 node_modules에 있는 styled-components와 프로젝트의 styled-components가 충돌이 나더라고요. 실제로 가끔 CSS가 동작하지 않을 때가 있습니다..
저도 전에 NPM 배포 미션을 할 때 react를 dependencies에 넣었다가 이슈를 겪었었는데요.

스타일드 컴포넌트 [문서](https://styled-components.com/docs/faqs#i-am-a-library-author.-should-i-bundle-styled-components-with-my-library)를 참고해서 종속성을 수정해보았습니다. 

dev로 옮기면 직접 설치는 안되는데, peer에도 적으면 해당 패키지가 없으면 경고를 해준다고 하더라고요.
사용할 프로젝트에 react, react-dom, styled-components는 있을 테니까 이렇게 수정하면 어떨까요?

어떠한 의견 환영합니다




